### PR TITLE
Update for Fondant 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fondant==0.6.2
+fondant==0.7.0
 notebook==7.0.6

--- a/src/notebook.ipynb
+++ b/src/notebook.ipynb
@@ -27,13 +27,62 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment\n",
+    "### This section checks the prerequisites of your environment. Read any errors or warnings carefully."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Ensure a Python between version 3.8 and 3.10 is available**"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Setup your environment \n",
-    "!pip install \"fondant==0.6.2\""
+    "import sys\n",
+    "if sys.version_info < (3, 8, 0) or sys.version_info >= (3, 11, 0):\n",
+    "    raise Exception(f\"A Python version between 3.8 and 3.10 is required. You are running {sys.version}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Check if docker compose is installed and the docker daemon is running**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker compose version >/dev/null\n",
+    "!docker info >/dev/null"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Install Fondant**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r ../requirements.txt"
    ]
   },
   {
@@ -51,16 +100,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fsspec\n",
     "from fondant.pipeline import ComponentOp, Pipeline\n",
     "from pathlib import Path\n",
     "\n",
     "BASE_PATH = \"./data-dir\"\n",
     "\n",
-    "# Create data directory if it doesn't exist and if it's a local path\n",
-    "if fsspec.core.url_to_fs(BASE_PATH)[0].protocol == ('file', 'local'):\n",
-    "    Path(BASE_PATH).mkdir(parents=True, exist_ok=True)\n",
-    "\n",
+    "# Create data directory if it doesn't exist\n",
+    "Path(BASE_PATH).mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "pipeline = Pipeline(\n",
     "    pipeline_name=\"filter-creative-commons\",  # Add a unique pipeline name to easily track your progress and data\n",
@@ -231,8 +277,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fondant.compiler import DockerCompiler\n",
-    "from fondant.runner import DockerRunner\n",
+    "from fondant.pipeline.compiler import DockerCompiler\n",
+    "from fondant.pipeline.runner import DockerRunner\n",
     "\n",
     "DockerCompiler().compile(pipeline, output_path=\"docker-compose.yaml\")\n",
     "DockerRunner().run(\"docker-compose.yaml\")"
@@ -253,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fondant.explorer import run_explorer_app\n",
+    "from fondant.explore import run_explorer_app\n",
     "\n",
     "run_explorer_app(\n",
     "    base_path=BASE_PATH,\n",
@@ -262,11 +308,18 @@
     "    port=8501\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -280,9 +333,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I already published Fondant 0.7.0 to `test.pypi` so we can upgrade our examples and test them against it (which I did). The main change is the split of the component and pipeline SDKs.

This PR also includes some improvements to the notebook which we already did in the other repositories.